### PR TITLE
feat: Rename WAL commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
 lint:
 	@echo "Running pre-commit hooks"
 	@pre-commit run --all-files
+
 pre-commit:
 	@echo "Linting last commit"
 	@pre-commit run --from-ref HEAD~1 --to-ref HEAD
+
 dependencies:
 	@echo "Installing dependencies"
 	@poetry update
+
 install:
 	@echo "Installing the project"
 	@poetry install
+
+.PHONY: test
 test:
-	@echo "Running tests"
+	@echo "Running Pythontests"
 	@poetry run pytest
+
 build-docker:
 	@echo "Building docker image"
 	@docker build -t chromadb-dp .

--- a/README.md
+++ b/README.md
@@ -168,42 +168,69 @@ This section presents general Chroma persistent dir info.
   to Chroma as they are not part of the metadata. This set should always be empty, if not please report it!!!
 - Fragmentation Level - the fragmentation level of the HNSW index.
 
-### WAL Commit
+### WAL Maintenance
+
+#### Commit
 
 This command ensures your WAL is committed to binary vector index (HNSW).
 
+**Python:**
+
 ```bash
-chops commit-wal /path/to/persist_dir
+chops wal commit /path/to/persist_dir
 ```
 
-> Note: You can skip certain collections by running `chops commit-wal /path/to/persist_dir --skip <collection_name>`
+> [!TIP]
+> You can skip certain collections by running `chops wal commit /path/to/persist_dir --skip <collection_name>`
 
-### WAL Cleanup
+**Go:**
+
+> [!NOTE]
+> Coming soon
+
+#### Cleanup
 
 This command cleans up the committed portion of the WAL and VACUUMs the database.
 
+**Python:**
+
 ```bash
-chops clean-wal /path/to/persist_dir
+chops wal clean /path/to/persist_dir
 ```
 
-### WAL Export
+**Go:**
+
+> [!NOTE]
+> Coming soon
+
+#### Export
 
 This commands exports the WAL to a `jsonl` file. The command can be useful in taking backups of the WAL.
 
+**Python:**
+
 ```bash
-chops export-wal /path/to/persist_dir --out /path/to/export.jsonl
+chops wal export /path/to/persist_dir --out /path/to/export.jsonl
 ```
 
-> Note: If --out or -o is not specified the command will print the output to stdout.
+> [!NOTE]
+> If --out or -o is not specified the command will print the output to stdout.
 
-### Full-Text Search (FTS) Index Rebuild
+**Go:**
+
+> [!NOTE]
+> Coming soon
+
+### Full-Text Search (FTS) Maintenance
+
+#### Rebuild
 
 This command rebuilds the full-text search index.
 
 > Note: **_Why is this needed_**? Users have reported broken FTS indices that result in a error of this
 > kind: `no such table: embedding_fulltext_search`
 
-#### Python
+**Python:**
 
 ```bash
 chops fts rebuild /path/to/persist_dir
@@ -215,9 +242,10 @@ Change the tokenizer to `unicode61` by passing `--tokenizer unicode61` (or `-t u
 chops fts rebuild --tokenizer unicode61 /path/to/persist_dir
 ```
 
+> [!TIP]
 > See [SQLite FTS5 Tokenizers](https://www.sqlite.org/fts5.html#tokenizers) for more information and available tokenizers and their options.
 
-#### Go
+**Go:**
 
 ```bash
 chops fts rebuild /path/to/persist_dir
@@ -239,7 +267,8 @@ This command cleans up orphaned vector segment directories.
 chops clean /path/to/persist_dir
 ```
 
-> Note: The command is particularly useful for windows users where deleting collections may leave behind orphaned vector
+> [!TIP]
+> The command is particularly useful for windows users where deleting collections may leave behind orphaned vector
 > segment directories due to Windows file locking.
 
 For the `go` version of the tool the command it is also possible to use `--dry-run` option to see what would be deleted
@@ -250,7 +279,7 @@ without actually deleting anything.
 
 #### Info
 
-##### Python
+**Python:**
 
 ```bash
 chops hnsw info /path/to/persist_dir --collection <collection_name>
@@ -261,14 +290,14 @@ Additional options:
 - `--database` (`-d`) - the database name (default: `default_database`)
 - `--verbose` (`-v`) - If specified, the HNSW index will be loaded for more accurate fragmentation level reporting.
 
-##### Go
+**Go:**
 
 > [!NOTE]
 > Coming soon
 
 #### Rebuild
 
-##### Python
+**Python:**
 
 ```bash
 chops hnsw rebuild /path/to/persist_dir --collection <collection_name>
@@ -280,7 +309,7 @@ Additional options:
 - `--database` (`-d`) - the database name (default: `default_database`)
 - `--yes` (`-y`) - skip confirmation prompt
 
-##### Go
+**Go:**
 
 > [!NOTE]
 > Coming soon

--- a/chroma_ops/clean.py
+++ b/chroma_ops/clean.py
@@ -3,13 +3,12 @@ import os
 import shutil
 import sqlite3
 import sys
-import uuid
 
 import typer
 from chroma_ops.utils import validate_chroma_persist_dir
 
 
-def clean(persist_dir: str):
+def clean(persist_dir: str) -> None:
     validate_chroma_persist_dir(persist_dir)
     sql_file = os.path.join(persist_dir, "chroma.sqlite3")
     conn = sqlite3.connect(f"file:{sql_file}?mode=ro", uri=True)

--- a/chroma_ops/fts.py
+++ b/chroma_ops/fts.py
@@ -10,6 +10,7 @@ from chroma_ops.utils import validate_chroma_persist_dir, read_script
 
 fts_commands = typer.Typer()
 
+
 def validate_tokenizer(tokenizer: str) -> None:
     valid_tokenizers = ["trigram", "unicode61", "ascii", "porter"]
     if (

--- a/chroma_ops/hnsw.py
+++ b/chroma_ops/hnsw.py
@@ -5,7 +5,7 @@ import shutil
 import sqlite3
 import tempfile
 import traceback
-from typing import Any, Dict, Optional, TypedDict
+from typing import Dict, Optional, TypedDict
 import hnswlib
 import typer
 from rich.console import Console
@@ -17,7 +17,9 @@ from chroma_ops.utils import (
     PersistentData,
     sizeof_fmt,
 )
+
 hnsw_commands = typer.Typer()
+
 
 class HnswDetails(TypedDict):
     collection_name: str
@@ -36,19 +38,31 @@ class HnswDetails(TypedDict):
     has_metadata: bool
     num_elements: int
     id_to_label: Dict[str, int]
-    collection_id: int
+    collection_id: str
     index_size: str
     fragmentation_level: float
     fragmentation_level_estimated: bool
 
 
-def _get_hnsw_details(conn: sqlite3.Connection, persist_dir: str, collection_name: str, database: Optional[str] = "default_database", verbose: Optional[bool] = False) -> None:
-    collection_details = conn.execute("SELECT id,dimension FROM collections WHERE name = ?", (collection_name,)).fetchone()
+def _get_hnsw_details(
+    conn: sqlite3.Connection,
+    persist_dir: str,
+    collection_name: str,
+    database: Optional[str] = "default_database",
+    verbose: Optional[bool] = False,
+) -> HnswDetails:
+    collection_details = conn.execute(
+        "SELECT id,dimension FROM collections WHERE name = ?", (collection_name,)
+    ).fetchone()
     # config = json.loads(collection_details[1])
-    config= {}
-    
-    segment_id = conn.execute("SELECT id FROM segments WHERE scope = 'VECTOR' AND collection = ?", (collection_details[0],)).fetchone()
-    segment_metadata = conn.execute(""" SELECT json_object(
+    config = {}
+
+    segment_id = conn.execute(
+        "SELECT id FROM segments WHERE scope = 'VECTOR' AND collection = ?",
+        (collection_details[0],),
+    ).fetchone()
+    segment_metadata = conn.execute(
+        """ SELECT json_object(
     'segment_id', segment_id,
     'metadata', json_object(
         'hnsw:search_ef',MAX(CASE WHEN key = 'hnsw:search_ef' THEN int_value END),
@@ -61,39 +75,83 @@ def _get_hnsw_details(conn: sqlite3.Connection, persist_dir: str, collection_nam
         'hnsw:resize_factor', MAX(CASE WHEN key = 'hnsw:resize_factor' THEN float_value END)
         )
     ) AS result_json
-    FROM segment_metadata WHERE segment_id = ?""", (segment_id[0],)).fetchone()
-    
+    FROM segment_metadata WHERE segment_id = ?""",
+        (segment_id[0],),
+    ).fetchone()
+
     config = json.loads(segment_metadata[0])["metadata"]
-    space = config["hnsw:space"] if "hnsw:space" in config and config["hnsw:space"] else "l2"
-    ef_construction = config["hnsw:construction_ef"] if "hnsw:construction_ef" in config and config["hnsw:construction_ef"] else 100
-    ef_search = config["hnsw:search_ef"] if "hnsw:search_ef" in config and config["hnsw:search_ef"] else 100
+    space = (
+        config["hnsw:space"]
+        if "hnsw:space" in config and config["hnsw:space"]
+        else "l2"
+    )
+    ef_construction = (
+        config["hnsw:construction_ef"]
+        if "hnsw:construction_ef" in config and config["hnsw:construction_ef"]
+        else 100
+    )
+    ef_search = (
+        config["hnsw:search_ef"]
+        if "hnsw:search_ef" in config and config["hnsw:search_ef"]
+        else 100
+    )
     m = config["hnsw:M"] if "hnsw:M" in config and config["hnsw:M"] else 16
-    num_threads = config["hnsw:num_threads"] if "hnsw:num_threads" in config and config["hnsw:num_threads"] else 1
-    resize_factor = config["hnsw:resize_factor"] if "hnsw:resize_factor" in config and config["hnsw:resize_factor"] else 1.2
-    batch_size = config["hnsw:batch_size"] if "hnsw:batch_size" in config and config["hnsw:batch_size"] else 100
-    sync_threshold = config["hnsw:sync_threshold"] if "hnsw:sync_threshold" in config and config["hnsw:sync_threshold"] else 1000
+    num_threads = (
+        config["hnsw:num_threads"]
+        if "hnsw:num_threads" in config and config["hnsw:num_threads"]
+        else 1
+    )
+    resize_factor = (
+        config["hnsw:resize_factor"]
+        if "hnsw:resize_factor" in config and config["hnsw:resize_factor"]
+        else 1.2
+    )
+    batch_size = (
+        config["hnsw:batch_size"]
+        if "hnsw:batch_size" in config and config["hnsw:batch_size"]
+        else 100
+    )
+    sync_threshold = (
+        config["hnsw:sync_threshold"]
+        if "hnsw:sync_threshold" in config and config["hnsw:sync_threshold"]
+        else 1000
+    )
     dimensions = collection_details[1]
     id_to_label = {}
     fragmentation_level = 0.0
     fragmentation_level_estimated = True
 
-    if os.path.exists(os.path.join(persist_dir, segment_id[0],"index_metadata.pickle")):
+    if os.path.exists(
+        os.path.join(persist_dir, segment_id[0], "index_metadata.pickle")
+    ):
         has_metadata = True
-        persistent_data = PersistentData.load_from_file(os.path.join(persist_dir, segment_id[0], "index_metadata.pickle"))
+        persistent_data = PersistentData.load_from_file(
+            os.path.join(persist_dir, segment_id[0], "index_metadata.pickle")
+        )
         id_to_label = persistent_data.id_to_label
-        if len(id_to_label)>0:
-            fragmentation_level = (persistent_data.total_elements_added - len(id_to_label)) / persistent_data.total_elements_added * 100
+        if len(id_to_label) > 0:
+            fragmentation_level = (
+                (persistent_data.total_elements_added - len(id_to_label))
+                / persistent_data.total_elements_added
+                * 100
+            )
         else:
             fragmentation_level = 0.0
             fragmentation_level_estimated = False
         if verbose:
             index = hnswlib.Index(space=space, dim=dimensions)
-            index.load_index(os.path.join(persist_dir, segment_id[0]), is_persistent_index=True, max_elements=len(id_to_label))
+            index.load_index(
+                os.path.join(persist_dir, segment_id[0]),
+                is_persistent_index=True,
+                max_elements=len(id_to_label),
+            )
             index.set_num_threads(num_threads)
             index.set_ef(ef_search)
             total_elements = index.element_count
             if total_elements > 0:
-                fragmentation_level = (total_elements - len(id_to_label)) / total_elements * 100
+                fragmentation_level = (
+                    (total_elements - len(id_to_label)) / total_elements * 100
+                )
                 fragmentation_level_estimated = False
             else:
                 fragmentation_level = 0.0
@@ -101,11 +159,10 @@ def _get_hnsw_details(conn: sqlite3.Connection, persist_dir: str, collection_nam
             index.close_file_handles()
     else:
         has_metadata = False
-        
 
     return HnswDetails(
         collection_name=collection_name,
-        database=database,
+        database=database if database else "default_database",
         space=space,
         dimensions=dimensions,
         ef_construction=ef_construction,
@@ -121,38 +178,53 @@ def _get_hnsw_details(conn: sqlite3.Connection, persist_dir: str, collection_nam
         num_elements=len(id_to_label),
         id_to_label=id_to_label,
         collection_id=collection_details[0],
-        index_size=sizeof_fmt(get_dir_size(os.path.join(persist_dir, segment_id[0])),),
+        index_size=sizeof_fmt(
+            get_dir_size(os.path.join(persist_dir, segment_id[0])),
+        ),
         fragmentation_level=fragmentation_level,
         fragmentation_level_estimated=fragmentation_level_estimated,
     )
 
-def print_hnsw_details(hnsw_details: Dict[str, Any]) -> None:
+
+def print_hnsw_details(hnsw_details: HnswDetails) -> None:
     console = Console()
-    table = Table(title=f"HNSW details for collection [red]{hnsw_details['collection_name']}[/red] in [red]{hnsw_details['database']}[/red] database")
-    
+    table = Table(
+        title=f"HNSW details for collection [red]{hnsw_details['collection_name']}[/red] in [red]{hnsw_details['database']}[/red] database"
+    )
+
     table.add_column("Metric", style="cyan")
     table.add_column("Value", style="green")
-    
+
     # Add rows for each detail
-    table.add_row("Space", str(hnsw_details['space']))
-    table.add_row("Dimensions", str(hnsw_details['dimensions']))
-    table.add_row("EF Construction", str(hnsw_details['ef_construction']))
-    table.add_row("EF Search", str(hnsw_details['ef_search']))
-    table.add_row("M", str(hnsw_details['m']))
-    table.add_row("Number of threads", str(hnsw_details['num_threads']))
-    table.add_row("Resize factor", str(hnsw_details['resize_factor']))
-    table.add_row("Batch size", str(hnsw_details['batch_size']))
-    table.add_row("Sync threshold", str(hnsw_details['sync_threshold']))
-    table.add_row("Segment ID", hnsw_details['segment_id'])
-    table.add_row("Path", hnsw_details['path'])
-    table.add_row("Has metadata", str(hnsw_details['has_metadata']))
-    table.add_row("Number of elements", str(hnsw_details['num_elements']))
-    table.add_row("Collection ID", str(hnsw_details['collection_id']))
-    table.add_row("Index size", hnsw_details['index_size'])
-    table.add_row("Fragmentation level", f"{hnsw_details['fragmentation_level']:.2f}% {'(estimated)' if hnsw_details['fragmentation_level_estimated'] else ''}")
+    table.add_row("Space", str(hnsw_details["space"]))
+    table.add_row("Dimensions", str(hnsw_details["dimensions"]))
+    table.add_row("EF Construction", str(hnsw_details["ef_construction"]))
+    table.add_row("EF Search", str(hnsw_details["ef_search"]))
+    table.add_row("M", str(hnsw_details["m"]))
+    table.add_row("Number of threads", str(hnsw_details["num_threads"]))
+    table.add_row("Resize factor", str(hnsw_details["resize_factor"]))
+    table.add_row("Batch size", str(hnsw_details["batch_size"]))
+    table.add_row("Sync threshold", str(hnsw_details["sync_threshold"]))
+    table.add_row("Segment ID", hnsw_details["segment_id"])
+    table.add_row("Path", hnsw_details["path"])
+    table.add_row("Has metadata", str(hnsw_details["has_metadata"]))
+    table.add_row("Number of elements", str(hnsw_details["num_elements"]))
+    table.add_row("Collection ID", str(hnsw_details["collection_id"]))
+    table.add_row("Index size", hnsw_details["index_size"])
+    table.add_row(
+        "Fragmentation level",
+        f"{hnsw_details['fragmentation_level']:.2f}% {'(estimated)' if hnsw_details['fragmentation_level_estimated'] else ''}",
+    )
     console.print(table)
 
-def rebuild_hnsw(persist_dir: str, collection_name: str, database: Optional[str] = "default_database", backup: Optional[bool] = True, yes: Optional[bool] = False) -> None:
+
+def rebuild_hnsw(
+    persist_dir: str,
+    collection_name: str,
+    database: Optional[str] = "default_database",
+    backup: Optional[bool] = True,
+    yes: Optional[bool] = False,
+) -> None:
     """Rebuilds the HNSW index in-place"""
     validate_chroma_persist_dir(persist_dir)
     console = Console()
@@ -163,7 +235,9 @@ def rebuild_hnsw(persist_dir: str, collection_name: str, database: Optional[str]
     try:
         hnsw_details = _get_hnsw_details(conn, persist_dir, collection_name, database)
         if not hnsw_details["has_metadata"]:
-            console.print(f"[red]Index metadata not found for segment {hnsw_details['segment_id']}. No need to rebuild.[/red]")
+            console.print(
+                f"[red]Index metadata not found for segment {hnsw_details['segment_id']}. No need to rebuild.[/red]"
+            )
             return
         space = hnsw_details["space"]
         ef_construction = hnsw_details["ef_construction"]
@@ -180,16 +254,20 @@ def rebuild_hnsw(persist_dir: str, collection_name: str, database: Optional[str]
             shutil.copytree(os.path.join(persist_dir, segment_id), temp_persist_dir)
             target_index = hnswlib.Index(space=space, dim=dimensions)
             target_index.init_index(
-                            max_elements=len(id_to_label),
-                            ef_construction=ef_construction, 
-                            M=m,
-                            is_persistent_index=True,
-                            persistence_location=temp_persist_dir, 
-                            )
+                max_elements=len(id_to_label),
+                ef_construction=ef_construction,
+                M=m,
+                is_persistent_index=True,
+                persistence_location=temp_persist_dir,
+            )
             target_index.set_num_threads(num_threads)
             target_index.set_ef(ef_search)
             source_index = hnswlib.Index(space=space, dim=dimensions)
-            source_index.load_index(os.path.join(persist_dir, segment_id), is_persistent_index=True, max_elements=len(id_to_label))
+            source_index.load_index(
+                os.path.join(persist_dir, segment_id),
+                is_persistent_index=True,
+                max_elements=len(id_to_label),
+            )
             source_index.set_num_threads(num_threads)
             values = list(id_to_label.values())
             print_hnsw_details(hnsw_details)
@@ -202,28 +280,44 @@ def rebuild_hnsw(persist_dir: str, collection_name: str, database: Optional[str]
                     console.print("[yellow]Rebuild cancelled by user[/yellow]")
                     return
             with Progress(
-                SpinnerColumn(finished_text="[bold green]:heavy_check_mark:[/bold green]"),
+                SpinnerColumn(
+                    finished_text="[bold green]:heavy_check_mark:[/bold green]"
+                ),
                 TextColumn("[progress.description]{task.description}"),
-                *[BarColumn(), TextColumn("{task.percentage:>3.0f}%")],  # Add these columns
+                *[
+                    BarColumn(),
+                    TextColumn("{task.percentage:>3.0f}%"),
+                ],  # Add these columns
                 transient=True,
             ) as progress:
-                task = progress.add_task("Adding items to target index...", total=len(values))
+                task = progress.add_task(
+                    "Adding items to target index...", total=len(values)
+                )
                 for i in range(0, len(values), batch_size):
-                    items = source_index.get_items(ids=values[i:i+batch_size])
-                    target_index.add_items(items, values[i:i+batch_size])
+                    items = source_index.get_items(ids=values[i : i + batch_size])
+                    target_index.add_items(items, values[i : i + batch_size])
                     progress.update(task, advance=len(items))
             target_index.persist_dirty()
             target_index.close_file_handles()
             source_index.close_file_handles()
             if backup:
-                backup_target = os.path.join(persist_dir, f"{segment_id}_backup_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}")
+                backup_target = os.path.join(
+                    persist_dir,
+                    f"{segment_id}_backup_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}",
+                )
                 shutil.move(os.path.join(persist_dir, segment_id), backup_target)
-                console.print(f"[bold green]Backup of old index created at {backup_target}[/bold green]")
+                console.print(
+                    f"[bold green]Backup of old index created at {backup_target}[/bold green]"
+                )
             else:
                 shutil.rmtree(os.path.join(persist_dir, segment_id))
             shutil.copytree(temp_persist_dir, os.path.join(persist_dir, segment_id))
         conn.commit()
-        print_hnsw_details(_get_hnsw_details(conn, persist_dir, collection_name, database,verbose=True))
+        print_hnsw_details(
+            _get_hnsw_details(
+                conn, persist_dir, collection_name, database, verbose=True
+            )
+        )
     except Exception:
         conn.rollback()
         console.print("[red]Failed to rebuild HNSW index[/red]")
@@ -232,13 +326,21 @@ def rebuild_hnsw(persist_dir: str, collection_name: str, database: Optional[str]
     finally:
         conn.close()
 
-def info_hnsw(persist_dir: str, collection_name: str, database: Optional[str] = "default_database", verbose: Optional[bool] = False) -> HnswDetails:
+
+def info_hnsw(
+    persist_dir: str,
+    collection_name: str,
+    database: Optional[str] = "default_database",
+    verbose: Optional[bool] = False,
+) -> HnswDetails:
     validate_chroma_persist_dir(persist_dir)
     console = Console()
     sql_file = os.path.join(persist_dir, "chroma.sqlite3")
     conn = sqlite3.connect(f"file:{sql_file}?mode=rw", uri=True)
     try:
-        hnsw_details = _get_hnsw_details(conn, persist_dir, collection_name, database, verbose=verbose)
+        hnsw_details = _get_hnsw_details(
+            conn, persist_dir, collection_name, database, verbose=verbose
+        )
         print_hnsw_details(hnsw_details)
         return hnsw_details
     except Exception:
@@ -248,9 +350,12 @@ def info_hnsw(persist_dir: str, collection_name: str, database: Optional[str] = 
     finally:
         conn.close()
 
+
 def rebuild_hnsw_command(
     persist_dir: str = typer.Argument(..., help="The persist directory"),
-    collection_name: str = typer.Option(..., "--collection", "-c", help="The collection name"),
+    collection_name: str = typer.Option(
+        ..., "--collection", "-c", help="The collection name"
+    ),
     database: str = typer.Option(
         "default_database",
         "--database",
@@ -278,9 +383,12 @@ def rebuild_hnsw_command(
         yes,
     )
 
+
 def info_hnsw_command(
     persist_dir: str = typer.Argument(..., help="The persist directory"),
-    collection_name: str = typer.Option(..., "--collection", "-c", help="The collection name"),
+    collection_name: str = typer.Option(
+        ..., "--collection", "-c", help="The collection name"
+    ),
     database: str = typer.Option(
         "default_database",
         "--database",
@@ -296,6 +404,7 @@ def info_hnsw_command(
 ) -> None:
     info_hnsw(persist_dir, collection_name, database, verbose)
 
+
 hnsw_commands.command(
     name="rebuild",
     help="Rebuild the HNSW index",
@@ -307,4 +416,3 @@ hnsw_commands.command(
     help="Info about the HNSW index",
     no_args_is_help=True,
 )(info_hnsw_command)
-

--- a/chroma_ops/main.py
+++ b/chroma_ops/main.py
@@ -1,27 +1,15 @@
 import typer
 
 from chroma_ops.fts import fts_commands
-from chroma_ops.wal_commit import command as commit_wal_command
-from chroma_ops.wal_clean import command as clean_wal_command
-from chroma_ops.wal_export import command as export_wal_command
+from chroma_ops.wal import wal_commands
 from chroma_ops.info import command as info_command
 from chroma_ops.clean import command as clean_command
 from chroma_ops.hnsw import hnsw_commands
 
 app = typer.Typer(no_args_is_help=True, help="ChromaDB Ops Commands.")
 
-app.command(
-    name="commit-wal", help="Commit WAL to HNSW lib binary index", no_args_is_help=True
-)(commit_wal_command)
 
-app.command(
-    name="clean-wal",
-    help="Cleans up WAL and VACUUM the SQLite DB.",
-    no_args_is_help=True,
-)(clean_wal_command)
-app.command(
-    name="export-wal", help="Exports the WAL to a jsonl file.", no_args_is_help=True
-)(export_wal_command)
+app.add_typer(wal_commands, name="wal", help="WAL maintenance commands")
 
 app.command(
     name="info",
@@ -37,7 +25,9 @@ app.command(
 )(clean_command)
 
 app.add_typer(hnsw_commands, name="hnsw", help="HNSW index maintenance commands")
-app.add_typer(fts_commands, name="fts", help="Full Text Search index maintenance commands")
+app.add_typer(
+    fts_commands, name="fts", help="Full Text Search index maintenance commands"
+)
 
 if __name__ == "__main__":
     app()

--- a/chroma_ops/wal.py
+++ b/chroma_ops/wal.py
@@ -1,0 +1,16 @@
+import typer
+from chroma_ops.wal_export import command as export_command
+from chroma_ops.wal_commit import command as commit_command
+from chroma_ops.wal_clean import command as clean_command
+
+wal_commands = typer.Typer(no_args_is_help=True)
+
+wal_commands.command(
+    name="export", no_args_is_help=True, help="Exports the WAL to a jsonl file."
+)(export_command)
+wal_commands.command(
+    name="commit", no_args_is_help=True, help="Commit WAL to HNSW lib binary index."
+)(commit_command)
+wal_commands.command(
+    name="clean", no_args_is_help=True, help="Cleans up WAL and VACUUM the SQLite DB."
+)(clean_command)

--- a/chroma_ops/wal_clean.py
+++ b/chroma_ops/wal_clean.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
-import argparse
 import os
 import sqlite3
 import sys
 from typing import Optional, Sequence
-
 import typer
 from chromadb import __version__ as chroma_version
 from chroma_ops.utils import (
@@ -105,11 +103,3 @@ def command(
     ),
 ) -> None:
     clean_wal(persist_dir, skip_collection_names=skip_collection_names)
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("persist_dir", type=str)
-    parser.add_argument("--skip-collection-names", type=str, default=None)
-    arg = parser.parse_args()
-    clean_wal(arg.persist_dir, skip_collection_names=arg.skip_collection_names)

--- a/chroma_ops/wal_commit.py
+++ b/chroma_ops/wal_commit.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import argparse
 import os
 import sys
 from typing import Sequence, Optional
@@ -76,11 +75,3 @@ def command(
     ),
 ) -> None:
     commit_wal(persist_dir, skip_collection_names=skip_collection_names)
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("persist-dir", type=str)
-    parser.add_argument("--skip-collection-names", type=str, default=None)
-    arg = parser.parse_args()
-    commit_wal(arg.persist_dir, skip_collection_names=arg.skip_collection_names)

--- a/chroma_ops/wal_export.py
+++ b/chroma_ops/wal_export.py
@@ -1,4 +1,3 @@
-import argparse
 import base64
 import json
 import os
@@ -56,11 +55,3 @@ def command(
     out: str = typer.Option(None, "--out", "-o", help="The output jsonl file"),
 ) -> None:
     export_wal(persist_dir, out)
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("persist_dir", type=str)
-    parser.add_argument("--out", type=str, default=None)
-    arg = parser.parse_args()
-    export_wal(arg.persist_dir, arg.out)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -16,7 +16,7 @@ import hypothesis.strategies as st
     number_of_collections=st.integers(min_value=1, max_value=10),
 )
 @settings(deadline=None)
-def test_clean(records_to_add: int, number_of_collections: int):
+def test_clean(records_to_add: int, number_of_collections: int) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         client = chromadb.PersistentClient(path=temp_dir)
         for i in range(number_of_collections):

--- a/tests/test_hnsw.py
+++ b/tests/test_hnsw.py
@@ -10,16 +10,33 @@ from chroma_ops.hnsw import info_hnsw, rebuild_hnsw, _get_hnsw_details
 from hypothesis import given, settings
 import hypothesis.strategies as st
 
+
 @given(verbose=st.booleans())
-def test_hnsw_info(verbose:bool) -> None:
+@settings(deadline=None)
+def test_hnsw_info(verbose: bool) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         client = chromadb.PersistentClient(path=temp_dir)
-        col = client.create_collection("test", metadata={"hnsw:search_ef":101, "hnsw:construction_ef":101, "hnsw:M":17, "hnsw:batch_size":101, "hnsw:sync_threshold":1001}) 
-        col.add(ids=["1", "2", "3"], documents=["document 1", "document 2", "document 3"], embeddings=[[0.1] * 384] * 3)
-        info_dict= info_hnsw(temp_dir, "test", verbose=verbose)
+        col = client.create_collection(
+            "test",
+            metadata={
+                "hnsw:search_ef": 101,
+                "hnsw:construction_ef": 101,
+                "hnsw:M": 17,
+                "hnsw:batch_size": 101,
+                "hnsw:sync_threshold": 1001,
+            },
+        )
+        col.add(
+            ids=["1", "2", "3"],
+            documents=["document 1", "document 2", "document 3"],
+            embeddings=[[0.1] * 384] * 3,
+        )
+        info_dict = info_hnsw(temp_dir, "test", verbose=verbose)
         assert info_dict["fragmentation_level"] == 0.0
         assert info_dict["collection_id"] == str(col.id)
-        assert info_dict["num_elements"] == 0 # with too few elements, metadata is not created
+        assert (
+            info_dict["num_elements"] == 0
+        )  # with too few elements, metadata is not created
         assert info_dict["dimensions"] == 384
         assert info_dict["ef_construction"] == 101
         assert info_dict["ef_search"] == 101
@@ -28,41 +45,56 @@ def test_hnsw_info(verbose:bool) -> None:
         assert info_dict["sync_threshold"] == 1001
         assert "segment_id" in info_dict
         assert info_dict["path"] == os.path.join(temp_dir, info_dict["segment_id"])
-        assert info_dict["has_metadata"] == False # with too few elements, metadata is not created
+        assert (
+            info_dict["has_metadata"] is False
+        )  # with too few elements, metadata is not created
         assert "index_size" in info_dict
         assert info_dict["fragmentation_level"] == 0.0
-        assert info_dict["fragmentation_level_estimated"] == True
-        shutil.copy2(os.path.join(temp_dir, "chroma.sqlite3") , os.path.join(".", "chroma_before.sqlite3"))
+        assert info_dict["fragmentation_level_estimated"] is True
+        shutil.copy2(
+            os.path.join(temp_dir, "chroma.sqlite3"),
+            os.path.join(".", "chroma_before.sqlite3"),
+        )
 
 
-@given(records_to_add=st.integers(min_value=100,max_value=10000),records_to_delete=st.integers(min_value=10,max_value=1000))
-@settings(deadline=None,max_examples=5)
-def test_hnsw_rebuild(records_to_add,records_to_delete) -> None:
+@given(
+    records_to_add=st.integers(min_value=100, max_value=10000),
+    records_to_delete=st.integers(min_value=10, max_value=1000),
+)
+@settings(deadline=None, max_examples=5)
+def test_hnsw_rebuild(records_to_add: int, records_to_delete: int) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
-        records_to_delete = min(records_to_delete,records_to_add)
-        sql_file = os.path.join(temp_dir, "chroma.sqlite3") 
+        records_to_delete = min(records_to_delete, records_to_add)
+        sql_file = os.path.join(temp_dir, "chroma.sqlite3")
         client = chromadb.PersistentClient(path=temp_dir)
         col = client.get_or_create_collection("test_collection")
         ids = [str(uuid.uuid4()) for _ in range(records_to_add)]
         documents = [f"document {i}" for i in range(records_to_add)]
         embeddings = np.random.uniform(0, 1, (records_to_add, 384)).tolist()
-        random_ids_to_delete = np.random.choice(ids, size=records_to_delete, replace=False)
+        random_ids_to_delete = np.random.choice(
+            ids, size=records_to_delete, replace=False
+        )
         col.add(ids=ids, documents=documents, embeddings=embeddings)
         col.delete(ids=random_ids_to_delete.tolist())
         conn = sqlite3.connect(sql_file)
         details = _get_hnsw_details(conn, temp_dir, "test_collection", verbose=True)
         conn.close()
         should_have_fragmentation = False
-        if records_to_add >= details["sync_threshold"] or records_to_add+records_to_delete >= details["sync_threshold"]:
+        if (
+            records_to_add >= details["sync_threshold"]
+            or records_to_add + records_to_delete >= details["sync_threshold"]
+        ):
             if records_to_delete > details["sync_threshold"]:
                 assert details["fragmentation_level"] > 0.0
-            elif int((records_to_add+records_to_delete) / details["sync_threshold"]) > int(records_to_add/details["sync_threshold"]):
+            elif int(
+                (records_to_add + records_to_delete) / details["sync_threshold"]
+            ) > int(records_to_add / details["sync_threshold"]):
                 assert details["fragmentation_level"] > 0.0
             else:
                 assert details["fragmentation_level"] == 0.0
         else:
             assert details["fragmentation_level"] == 0.0
-        rebuild_hnsw(temp_dir, "test_collection",yes=True)
+        rebuild_hnsw(temp_dir, "test_collection", yes=True)
         if should_have_fragmentation:
             conn = sqlite3.connect(sql_file)
             details = _get_hnsw_details(conn, temp_dir, "test_collection", verbose=True)
@@ -80,4 +112,3 @@ def test_hnsw_rebuild(records_to_add,records_to_delete) -> None:
         col.add(ids=new_ids, documents=new_documents, embeddings=new_embeddings)
         new_random_ids_to_delete = np.random.choice(new_ids, size=10, replace=False)
         col.delete(ids=new_random_ids_to_delete.tolist())
-

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -5,6 +5,7 @@ from hypothesis import given, settings
 import hypothesis.strategies as st
 
 import chromadb
+from pytest import CaptureFixture
 
 from chroma_ops.info import info
 
@@ -25,7 +26,7 @@ def test_basic_info(records_to_add: int) -> None:
         assert len(export_data["collections"]) == 1
 
 
-def test_empty_collections(capsys) -> None:
+def test_empty_collections(capsys: CaptureFixture[str]) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         client = chromadb.PersistentClient(path=temp_dir)
         client.get_or_create_collection("test")
@@ -33,14 +34,14 @@ def test_empty_collections(capsys) -> None:
         assert len(export_data["collections"]) == 1
 
 
-def test_empty_db(capsys) -> None:
+def test_empty_db(capsys: CaptureFixture[str]) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         chromadb.PersistentClient(path=temp_dir)
         export_data = info(temp_dir)
         assert len(export_data["collections"]) == 0
 
 
-def test_skip_collection(capsys) -> None:
+def test_skip_collection(capsys: CaptureFixture[str]) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         client = chromadb.PersistentClient(path=temp_dir)
         client.get_or_create_collection("test")
@@ -48,7 +49,7 @@ def test_skip_collection(capsys) -> None:
         assert len(export_data["collections"]) == 0
 
 
-def test_privacy(capsys) -> None:
+def test_privacy(capsys: CaptureFixture[str]) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         client = chromadb.PersistentClient(path=temp_dir)
         client.get_or_create_collection("test")

--- a/tests/test_wal_commit.py
+++ b/tests/test_wal_commit.py
@@ -9,6 +9,7 @@ import hypothesis.strategies as st
 import chromadb
 from chromadb.segment import VectorReader
 from chromadb.types import SegmentScope
+from pytest import CaptureFixture
 
 from chroma_ops.wal_commit import commit_wal
 
@@ -131,7 +132,7 @@ def test_commit_skip_collection(records_to_add: int) -> None:
                 ), "Post failed"
 
 
-def test_empty_collections(capsys) -> None:
+def test_empty_collections(capsys: CaptureFixture[str]) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         client = chromadb.PersistentClient(path=temp_dir)
         client.create_collection("test")


### PR DESCRIPTION
Closes #62
Closes #63
Closes #70

- Updated README
- Removed `__main__` from WAL maintenance commands
- Fixed all linting errors


