### PR TITLE
docs: Adding --upgrade to the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A collection of utilities to help you managed single-node Chroma instances.
 ### Python
 
 ```bash
-pip install chromadb-ops
+pip install --upgrade chromadb-ops
 ```
 
 ### Go


### PR DESCRIPTION
Closes #114

Make it a tad bit easier when installing the dep to also upgrade it if it already exists

